### PR TITLE
日付の未入力表示、割合の警告、同じ教科名禁止

### DIFF
--- a/src/components/SubjectComponents/Form/AddSubject.jsx
+++ b/src/components/SubjectComponents/Form/AddSubject.jsx
@@ -39,12 +39,12 @@ export default function AddSubject({ close, setSubjectsData, subjectsData }) {
       finalExam: {
         rate: finalRate,
         score: 0,
-        Xday: new Date(),
+        Xday: "未入力",
       },
       middleExam: {
         rate: middleRate,
         score: 0,
-        Xday: new Date(),
+        Xday: "未入力",
       },
       smallExam: {
         rate: smallRate,
@@ -66,7 +66,15 @@ export default function AddSubject({ close, setSubjectsData, subjectsData }) {
 
   const onAddEvent = () => {
     console.log("add Event");
-    addSubjectData(subjectName, smallRate, middleRate, finalRate, reportRate);
+    if (!subjectsData.find((sub) => sub.name === subjectName)) {
+      addSubjectData(
+        subjectName,
+        Number(smallRate),
+        Number(middleRate),
+        Number(finalRate),
+        Number(reportRate)
+      );
+    }
   };
   return (
     <form onSubmit={handleSubmit}>

--- a/src/components/SubjectComponents/Form/ChaRepRate.jsx
+++ b/src/components/SubjectComponents/Form/ChaRepRate.jsx
@@ -28,7 +28,7 @@ export const ChaRepRate = ({ data, name, set }) => {
     };
     await updateDoc(doc(db, auth.currentUser.email, name), event);
     changeFlag();
-    set(rate);
+    set(Number(rate));
   };
   return (
     <Box

--- a/src/components/SubjectComponents/Form/ChangeFinal.jsx
+++ b/src/components/SubjectComponents/Form/ChangeFinal.jsx
@@ -22,7 +22,7 @@ export const ChangeFinal = ({ data, name, set }) => {
   const [Xday, setXday] = useState();
   const [score, setScore] = useState(data.score);
   const [flag, setFlag] = useState(false);
-  if (Xday === undefined) {
+  if (Xday === undefined && data.Xday !== "未入力") {
     // 前データの引継ぎ
     //Dateのタイムスタンプはミリ秒単位, Firestoreのタイムスタンプは秒単位？
     setXday(dayjs(data.Xday.seconds * 1000));

--- a/src/components/SubjectComponents/Form/ChangeMiddle.jsx
+++ b/src/components/SubjectComponents/Form/ChangeMiddle.jsx
@@ -21,7 +21,7 @@ export const ChangeMiddle = ({ data, name, set }) => {
   const [Xday, setXday] = useState();
   const [score, setScore] = useState(data.score);
   const [flag, setFlag] = useState(false);
-  if (Xday === undefined) {
+  if (Xday === undefined && data.Xday !== "未入力") {
     // 前データの引継ぎ
     setXday(dayjs(data.Xday.seconds * 1000));
   }

--- a/src/components/SubjectComponents/SubjectDetail.jsx
+++ b/src/components/SubjectComponents/SubjectDetail.jsx
@@ -142,7 +142,24 @@ export default function SubjectDetail() {
       </Box>
       <h1>得点率:{scoreRate}%</h1>
       <h1>得点:{score}</h1>
-
+      {finalExamData !== null &&
+        middleExamData !== null &&
+        reportRate !== null &&
+        smallExamRate !== null &&
+        reportRate +
+          smallExamRate +
+          middleExamData.rate +
+          finalExamData.rate !==
+          100 && (
+          <p style={{ color: "red" }}>
+            割合の合計が100%ではありません（現在
+            {reportRate +
+              smallExamRate +
+              middleExamData.rate +
+              finalExamData.rate}
+            ％）
+          </p>
+        )}
       <Report
         reportData={reportData}
         reportRate={reportRate}

--- a/src/components/SubjectComponents/SubjectInfo/MiddleExam.jsx
+++ b/src/components/SubjectComponents/SubjectInfo/MiddleExam.jsx
@@ -41,7 +41,9 @@ export default function MiddleExam({ middleExamData, name, set }) {
                     color="text.primary"
                   >
                     {"実施日 : " +
-                      ("seconds" in middleExamData.Xday
+                      (middleExamData.Xday === "未入力"
+                        ? "未入力"
+                        : "seconds" in middleExamData.Xday
                         ? middleExamData.Xday.toDate().toLocaleDateString()
                         : new Date(middleExamData.Xday).toLocaleDateString())}
                   </Typography>

--- a/src/components/SubjectComponents/SubjectInfo/finalExam.jsx
+++ b/src/components/SubjectComponents/SubjectInfo/finalExam.jsx
@@ -42,7 +42,9 @@ export default function FinalExam({ finalExamData, name, set }) {
                     color="text.primary"
                   >
                     {"実施日 : " +
-                      ("seconds" in finalExamData.Xday
+                      (finalExamData.Xday === "未入力"
+                        ? "未入力"
+                        : "seconds" in finalExamData.Xday
                         ? finalExamData.Xday.toDate().toLocaleDateString()
                         : new Date(finalExamData.Xday).toLocaleDateString())}
                   </Typography>


### PR DESCRIPTION
警告のデザインは変えていたただいて良いです。初期設定で確定を押したら強制的にフォームがcloseされるようなので、同じ教科名の場合はcloseしないように変えていたただきたいです。